### PR TITLE
Add option for filename truncate prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ require('pqf').setup({
   -- How long filenames in the quickfix are allowed to be. 0 means no limit.
   -- Filenames above this limit will be truncated from the beginning with
   `filename_truncate_prefix`.
+
+  -- Prefix to use for truncated filenames.
   filename_truncate_prefix = '[...]',
 })
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ require('pqf').setup({
   -- How long filenames in the quickfix are allowed to be. 0 means no limit.
   -- Filenames above this limit will be truncated from the beginning with
   `filename_truncate_prefix`.
+  max_filename_length = 0,
 
   -- Prefix to use for truncated filenames.
   filename_truncate_prefix = '[...]',

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ require('pqf').setup({
   show_multiple_lines = false,
 
   -- How long filenames in the quickfix are allowed to be. 0 means no limit.
-  -- Filenames above this limit will be truncated from the beginning with [...]
-  max_filename_length = 0,
+  -- Filenames above this limit will be truncated from the beginning with
+  `filename_truncate_prefix`.
+  filename_truncate_prefix = '[...]',
 })
 ```
 

--- a/lua/pqf/init.lua
+++ b/lua/pqf/init.lua
@@ -14,6 +14,7 @@ local signs = {
 local namespace = api.nvim_create_namespace('pqf')
 local show_multiple_lines = false
 local max_filename_length = 0
+local filename_truncate_prefix = '[...]'
 
 -- If any of NeoVim's diagnostic signs are defined and have text set, we'll
 -- default to the text values of these signs. If some are missing, we'll fall
@@ -54,7 +55,7 @@ local function trim_path(path)
   local fname = fn.fnamemodify(path, ':p:.')
   local len = fn.strchars(fname)
   if max_filename_length > 0 and len > max_filename_length then
-    fname = '[...]'
+    fname = filename_truncate_prefix
       .. fn.strpart(
         fname,
         len - max_filename_length,
@@ -248,6 +249,14 @@ function M.setup(opts)
     assert(
       type(max_filename_length) == 'number',
       'the "max_filename_length" option must be a number'
+    )
+  end
+
+  if opts.filename_truncate_prefix then
+    filename_truncate_prefix = opts.filename_truncate_prefix
+    assert(
+      type(filename_truncate_prefix) == 'string',
+      'the "filename_truncate_prefix" option must be a string'
     )
   end
 


### PR DESCRIPTION
Hi!

Thank you for the plugin :)
There is a small change I would like to add.

When the `show_multiple_lines` option is not `0`, long filenames get truncated and prepended with the prefix `[...]`.
This PR adds the possibility to customize the prefix.

My personnal issues with the current prefix are:
- it is 5 characters long since it uses 3 dots instead of the ellipsis character `…`
- the `[` and `]` characters are usually the highest characters on the line and take too much visual space to me.