### PR TITLE
Don't hardcode sign highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Each item in the quickfix list starts with a sign that indicates the type of
 item, if this information is available. For example, when displaying diagnostics
 an item may start with `E` for an error, and `W` for a warning.
 
-These signs are taken from the `text` attribute of NeoVim's diagnostic signs.
+These signs and their highlight groups are taken from the `text` and `texthl`
+attributes of NeoVim's diagnostic signs.
 Refer to `:h diagnostic-signs` for more information, and details on how to
 override these signs.
 
@@ -84,10 +85,23 @@ The following highlight groups are used:
 |:------------------|:--------------------------
 | `Directory`       | The file path
 | `Number`          | Line and column numbers
-| `DiagnosticError` | The sign for errors
-| `DiagnosticWarn`  | The sign for warnings
-| `DiagnosticInfo`  | The sign for info messages
-| `DiagnosticHint`  | The sign for hints
+| `DiagnosticError` | The sign for errors (if `texthl` is missing)
+| `DiagnosticWarn`  | The sign for warnings (if `texthl` is missing)
+| `DiagnosticInfo`  | The sign for info messages (if `texthl` is missing)
+| `DiagnosticHint`  | The sign for hints (if `texthl` is missing)
+
+Highlight groups of signs can be overridden:
+
+```lua
+require('pqf').setup({
+  signs = {
+    error = {
+      text = 'E',
+      texthl = 'DiagnosticSignError'
+    }
+  }
+})
+```
 
 ## License
 

--- a/lua/pqf/init.lua
+++ b/lua/pqf/init.lua
@@ -32,8 +32,14 @@ local diagnostic_signs = {
 for diagnostic_sign, key in pairs(diagnostic_signs) do
   local sign_def = fn.sign_getdefined(diagnostic_sign)[1]
 
-  if sign_def and sign_def.text then
-    signs[key] = vim.trim(sign_def.text)
+  if sign_def then
+      signs[key] = {}
+    if sign_def.text then
+      signs[key].text = vim.trim(sign_def.text)
+    end
+    if sign_def.texthl then
+      signs[key].texthl = sign_def.texthl
+    end
   end
 end
 
@@ -95,10 +101,10 @@ function M.format(info)
   local lines = {}
   local pad_to = 0
   local type_mapping = {
-    E = { signs.error, 'DiagnosticError' },
-    W = { signs.warning, 'DiagnosticWarn' },
-    I = { signs.info, 'DiagnosticInfo' },
-    N = { signs.hint, 'DiagnosticHint' },
+    E = { signs.error.text, signs.error.texthl or 'DiagnosticError' },
+    W = { signs.warning.text, signs.warning.texthl or 'DiagnosticWarn' },
+    I = { signs.info.text, signs.info.texthl or 'DiagnosticInfo' },
+    N = { signs.hint.text, signs.hint.texthl or 'DiagnosticHint' },
   }
 
   local items = {}
@@ -251,7 +257,12 @@ function M.setup(opts)
 
   if opts.signs then
     assert(type(opts.signs) == 'table', 'the "signs" option must be a table')
-    signs = vim.tbl_extend('force', signs, opts.signs)
+    for key, val in pairs(opts.signs) do
+      if type(val) == 'string' then
+        opts.signs[key] = { text = val }
+      end
+    end
+    signs = vim.tbl_deep_extend('force', signs, opts.signs)
   end
 
   if opts.show_multiple_lines then


### PR DESCRIPTION
Hi! Thank you for developing nvim-pqf.

Currently, highlight groups of signs are hardcoded as `DiagnosticError`, `DiagnosticHint`, etc. However, I think it would be nicer to respect already defined `texthl` highlight groups for them.

With this patch, the plugin uses each sign's highlight group `texthl` if defined. Otherwise it falls back to default.

Moreover, it extends config to customize
highlight groups, like so:

```lua
require('pqf').setup({
  signs = {
    error = {
      text = 'E',
      texthl = 'DiagnosticSignError'
    }
  }
})
```