### PR TITLE
Add ability to hide line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ require('pqf').setup({
 
   -- Prefix to use for truncated filenames.
   filename_truncate_prefix = '[...]',
+
+  -- By default column numbers will be shown.
+  -- When this is true, only line numbers will be shown
+  hide_column_numbers = false,
 })
 ```
 

--- a/lua/pqf/init.lua
+++ b/lua/pqf/init.lua
@@ -13,6 +13,7 @@ local namespace = api.nvim_create_namespace('pqf')
 local show_multiple_lines = false
 local max_filename_length = 0
 local filename_truncate_prefix = '[...]'
+local hide_column_numbers = false
 
 local function pad_right(string, pad_to)
   local new = string
@@ -119,7 +120,7 @@ function M.format(info)
 
         -- Column numbers without line numbers make no sense, and may confuse
         -- the user into thinking they are actually line numbers.
-        if raw.col and raw.col > 0 then
+        if not hide_column_numbers and raw.col and raw.col > 0 then
           local col = raw.col
 
           if raw.end_col and raw.end_col > 0 and raw.end_col ~= col then
@@ -236,6 +237,10 @@ function M.setup(opts)
 
   if opts.show_multiple_lines then
     show_multiple_lines = true
+  end
+
+  if opts.hide_column_numbers then
+    hide_column_numbers = true
   end
 
   if opts.max_filename_length then


### PR DESCRIPTION
An information about column numbers is not used for me, so i decided to add feature to hide it.

Before:
![before](https://github.com/user-attachments/assets/5e2f0f22-afc3-4a41-a021-113984641bc3)

After:
![after](https://github.com/user-attachments/assets/8c88ae24-f29c-454b-9a8b-9d4feb86632a)

By default, column numbers will be displayed.

For testing i use example from https://github.com/yorickpeterse/nvim-pqf/pull/10#issuecomment-1783011863 , i think it's worked OK, also i didn't notice any errors while using my patched version.